### PR TITLE
Training Branch Updates

### DIFF
--- a/install-trainer.sh
+++ b/install-trainer.sh
@@ -5,6 +5,7 @@ echo "\nBurro Trainer Installer\n"
 echo "\nFor security and compatibility reasons this installer will not install any system-wide packages.\n"
 echo "\nIf you do not yet have your preferred Tensorflow version, you will have to install it yourself.\n"
 
+sudo apt-get install realpath
 
 echo "\nBurro Trainer Installer: Creating environment\n"
 pip install virtualenv

--- a/install-trainer.sh
+++ b/install-trainer.sh
@@ -5,8 +5,6 @@ echo "\nBurro Trainer Installer\n"
 echo "\nFor security and compatibility reasons this installer will not install any system-wide packages.\n"
 echo "\nIf you do not yet have your preferred Tensorflow version, you will have to install it yourself.\n"
 
-sudo apt-get install realpath
-
 echo "\nBurro Trainer Installer: Creating environment\n"
 pip install virtualenv
 virtualenv --system-site-packages burro-trainer

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -5,3 +5,4 @@ picamera==1.12
 Pillow==4.1.1
 keras==2.0.4
 pyusb==1.0.0
+configobj==5.0.6

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -3,6 +3,7 @@ setuptools==5.5.1
 tornado==4.4.2
 picamera==1.12
 Pillow==4.1.1
-keras==2.0.4
+keras==2.0.8
 pyusb==1.0.0
 configobj==5.0.6
+h5py==2.7.1

--- a/requirements-vehicle.txt
+++ b/requirements-vehicle.txt
@@ -3,4 +3,3 @@ picamera==1.12
 https://github.com/samjabrahams/tensorflow-on-raspberry-pi/releases/download/v1.1.0/tensorflow-1.1.0-cp27-none-linux_armv7l.whl
 keras==2.0.4
 pyusb==1.0.0
-configobj==5.0.6


### PR DESCRIPTION
I have been using the training branch to train up some models and I have found the following issues.

- Realpath was not installed by default on my OS (mint).
- Keras is required to be 2.0.8 for selu activation 
- h5py was required to save the model
- configobj was also required to load ini file.

