### PR TITLE
Keras is a common requirement its not required for the trainer.

### DIFF
--- a/requirements-trainer.txt
+++ b/requirements-trainer.txt
@@ -1,2 +1,1 @@
 -r requirements-common.txt
-keras==2.0.4


### PR DESCRIPTION
Stopps this error
Double requirement given: keras==2.0.4 (from -r requirements-trainer.txt (line 2)) (already in keras==2.0.8 (from -r requirements-common.txt (line 6)), name='keras')