### PR TITLE
Use confidence and predicted steering angle for throttle assignment

### DIFF
--- a/burro/config/defaults.ini
+++ b/burro/config/defaults.ini
@@ -48,7 +48,7 @@ right_reverse = False
 [model]
 input_range = (0, 255)
 output_size = 15
-yaw_step = 0.1
+yaw_step = 0.2
 throttle_average_factor = 0.9
 throttle_mult = 0.5
 

--- a/burro/config/defaults.ini
+++ b/burro/config/defaults.ini
@@ -49,6 +49,7 @@ right_reverse = False
 input_range = (0, 255)
 output_size = 15
 average_factor = 0.6
+max_throttle = 0.5
 
 [training]
 equalize_prob_strength = 0.99

--- a/burro/config/defaults.ini
+++ b/burro/config/defaults.ini
@@ -49,7 +49,7 @@ right_reverse = False
 input_range = (0, 255)
 output_size = 15
 average_factor = 0.6
-max_throttle = 0.5
+throttle_mult = 0.5
 
 [training]
 equalize_prob_strength = 0.99

--- a/burro/config/defaults.ini
+++ b/burro/config/defaults.ini
@@ -48,7 +48,8 @@ right_reverse = False
 [model]
 input_range = (0, 255)
 output_size = 15
-average_factor = 0.6
+yaw_average_factor = 0.6
+throttle_average_factor = 0.9
 throttle_mult = 0.5
 
 [training]

--- a/burro/config/defaults.ini
+++ b/burro/config/defaults.ini
@@ -48,7 +48,7 @@ right_reverse = False
 [model]
 input_range = (0, 255)
 output_size = 15
-yaw_average_factor = 0.6
+yaw_step = 0.1
 throttle_average_factor = 0.9
 throttle_mult = 0.5
 

--- a/burro/methods.py
+++ b/burro/methods.py
@@ -115,7 +115,10 @@ def current_milis():
 MISC
 '''
 
-def min_abs(v1, v2):
-    if abs(v1) <= abs(v2):
-        return v1
-    return v2
+def min_abs(vm, v):
+    if vm is None:
+        return v
+    if abs(vm) <= abs(v):
+        return vm
+    sign = -1 if vm < 0 else 1
+    return abs(v) * sign

--- a/burro/methods.py
+++ b/burro/methods.py
@@ -110,3 +110,12 @@ def current_milis():
     Return the current time in miliseconds
     '''
     return int(round(time.time() * 1000))
+
+'''
+MISC
+'''
+
+def min_abs(v1, v2):
+    if abs(v1) < abs(v2):
+        return v1
+    return v2

--- a/burro/methods.py
+++ b/burro/methods.py
@@ -116,6 +116,6 @@ MISC
 '''
 
 def min_abs(v1, v2):
-    if abs(v1) < abs(v2):
+    if abs(v1) <= abs(v2):
         return v1
     return v2

--- a/burro/pilots/cnn.py
+++ b/burro/pilots/cnn.py
@@ -58,12 +58,12 @@ class KerasCategorical(BasePilot):
         if len(prediction) == 2:
             throttle = prediction[1][0]
         else:
-            throttle = (0.12 + np.amax(yaw_binned) * (1 - abs(yaw)) *
+            throttle = (0.07 + np.amax(yaw_binned) * (1 - abs(yaw)) *
                        config.model.throttle_mult)
         avf_t = config.model.throttle_average_factor
         throttle = avf_t * self.throttle + (1.0 - avf_t) * throttle
         self.throttle = throttle
-        
+
         return methods.yaw_to_angle(yaw), throttle * -1
 
     def pname(self):

--- a/burro/pilots/cnn.py
+++ b/burro/pilots/cnn.py
@@ -41,16 +41,17 @@ class KerasCategorical(BasePilot):
         prediction = self.model.predict(img_arr)
         if len(prediction) == 2:
             yaw_binned = prediction[0]
-            throttle = prediction[1][0][0]
         else:
             yaw_binned = prediction
-            throttle = 0
         yaw = methods.from_one_hot(yaw_binned)
+
+        throttle = min(0.12 + np.amax(yaw_binned) * (1 - abs(yaw)),
+                       config.model.max_throttle)
 
         avf = config.model.average_factor
         yaw = avf * self.yaw + (1.0 - avf) * yaw
         self.yaw = yaw
-        return methods.yaw_to_angle(yaw), throttle * 0.15
+        return methods.yaw_to_angle(yaw), throttle
 
     def pname(self):
         return self.name or "Keras Categorical"

--- a/burro/pilots/cnn.py
+++ b/burro/pilots/cnn.py
@@ -45,17 +45,17 @@ class KerasCategorical(BasePilot):
         else:
             yaw_binned = prediction
         yaw = methods.from_one_hot(yaw_binned)
+        avf = config.model.average_factor
+        yaw = avf * self.yaw + (1.0 - avf) * yaw
+        self.yaw = yaw
 
         if len(prediction) == 2:
             throttle = prediction[1][0]
         else:
-            throttle = (-1 * (0.12 + np.amax(yaw_binned) * (1 - abs(yaw))) *
+            throttle = (0.12 + np.amax(yaw_binned) * (1 - abs(yaw)) *
                        config.model.throttle_mult)
 
-        avf = config.model.average_factor
-        yaw = avf * self.yaw + (1.0 - avf) * yaw
-        self.yaw = yaw
-        return methods.yaw_to_angle(yaw), throttle
+        return methods.yaw_to_angle(yaw), throttle * -1
 
     def pname(self):
         return self.name or "Keras Categorical"

--- a/burro/pilots/cnn.py
+++ b/burro/pilots/cnn.py
@@ -41,12 +41,16 @@ class KerasCategorical(BasePilot):
         prediction = self.model.predict(img_arr)
         if len(prediction) == 2:
             yaw_binned = prediction[0]
+            throttle = prediction[1][0]
         else:
             yaw_binned = prediction
         yaw = methods.from_one_hot(yaw_binned)
 
-        throttle = min(0.12 + np.amax(yaw_binned) * (1 - abs(yaw)),
-                       config.model.max_throttle)
+        if len(prediction) == 2:
+            throttle = prediction[1][0]
+        else:
+            throttle = (-1 * (0.12 + np.amax(yaw_binned) * (1 - abs(yaw))) *
+                       config.model.throttle_mult)
 
         avf = config.model.average_factor
         yaw = avf * self.yaw + (1.0 - avf) * yaw
@@ -88,7 +92,7 @@ class KerasRegression(BasePilot):
         avf = config.model.average_factor
         yaw = avf * self.yaw + (1.0 - avf) * yaw
         self.yaw = yaw
-        return methods.yaw_to_angle(yaw), throttle * 0.15
+        return methods.yaw_to_angle(yaw), throttle
 
     def pname(self):
         return self.name or "Keras Categorical"

--- a/burro/rover.py
+++ b/burro/rover.py
@@ -36,7 +36,7 @@ class Rover(object):
     def step(self):
         pilot_count = 0
         final_angle = 0.
-        final_throttle = 1.
+        final_throttle = 9.
         for pilot in self.manual_pilots:
             pilot_angle, pilot_throttle = pilot.decide(
                 self.vision_sensor.frame)

--- a/burro/rover.py
+++ b/burro/rover.py
@@ -1,6 +1,7 @@
 import sys
 import time
 
+from methods import min_abs
 
 class Rover(object):
     '''
@@ -33,21 +34,25 @@ class Rover(object):
             time.sleep(max(0.005, 0.05 - self.f_time))
 
     def step(self):
-        final_angle = 0
-        final_throttle = 0
+        pilot_count = 0
+        final_angle = 0.
+        final_throttle = 1.
         for pilot in self.manual_pilots:
             pilot_angle, pilot_throttle = pilot.decide(
                 self.vision_sensor.frame)
             final_angle += pilot_angle
-            final_throttle += pilot_throttle
+            final_throttle = min_abs(final_throttle, pilot_throttle)
+            pilot_count += 1
 
         if self.auto_pilot_index > -1:
             pilot = self.auto_pilots[self.auto_pilot_index];
             pilot_angle, pilot_throttle = pilot.decide(
                 self.vision_sensor.frame)
             final_angle += pilot_angle
-            final_throttle += pilot_throttle
+            final_throttle = min_abs(final_throttle, pilot_throttle)
+            pilot_count += 1
 
+        final_angle = final_angle / pilot_count
         self.mixer.update(final_throttle, final_angle)
 
         self.pilot_angle = final_angle

--- a/burro/rover.py
+++ b/burro/rover.py
@@ -36,7 +36,7 @@ class Rover(object):
     def step(self):
         pilot_count = 0
         final_angle = 0.
-        final_throttle = 9.
+        final_throttle = None
         for pilot in self.manual_pilots:
             pilot_angle, pilot_throttle = pilot.decide(
                 self.vision_sensor.frame)

--- a/burro/rover.py
+++ b/burro/rover.py
@@ -34,7 +34,6 @@ class Rover(object):
             time.sleep(max(0.005, 0.05 - self.f_time))
 
     def step(self):
-        pilot_count = 0
         final_angle = 0.
         final_throttle = None
         for pilot in self.manual_pilots:
@@ -42,7 +41,6 @@ class Rover(object):
                 self.vision_sensor.frame)
             final_angle += pilot_angle
             final_throttle = min_abs(final_throttle, pilot_throttle)
-            pilot_count += 1
 
         if self.auto_pilot_index > -1:
             pilot = self.auto_pilots[self.auto_pilot_index];
@@ -50,9 +48,7 @@ class Rover(object):
                 self.vision_sensor.frame)
             final_angle += pilot_angle
             final_throttle = min_abs(final_throttle, pilot_throttle)
-            pilot_count += 1
 
-        final_angle = final_angle / pilot_count
         self.mixer.update(final_throttle, final_angle)
 
         self.pilot_angle = final_angle

--- a/burro/sensors/cameras.py
+++ b/burro/sensors/cameras.py
@@ -19,7 +19,7 @@ class BaseCamera(BaseSensor):
 
     def __init__(self, resolution=config.camera.resolution, **kwargs):
         super(BaseCamera, self).__init__(**kwargs)
-        
+
         self.resolution = resolution
         self.frame = np.zeros(
             shape=(
@@ -79,7 +79,7 @@ class PiVideoStream(BaseCamera):
         self.camera.resolution = resolution
         self.camera.framerate = framerate
         self.camera.rotation = rotation
-        #self.camera.exposure_mode = "sports"
+        self.camera.exposure_mode = "sports"
         self.rawCapture = PiRGBArray(self.camera, size=resolution)
 
         self.frame = None

--- a/burro/sensors/cameras.py
+++ b/burro/sensors/cameras.py
@@ -79,7 +79,7 @@ class PiVideoStream(BaseCamera):
         self.camera.resolution = resolution
         self.camera.framerate = framerate
         self.camera.rotation = rotation
-        self.camera.exposure_mode = "sports"
+        #self.camera.exposure_mode = "sports"
         self.rawCapture = PiRGBArray(self.camera, size=resolution)
 
         self.frame = None


### PR DESCRIPTION
When using categorical output and explicit throttle value is missing, throttle is assigned based on predicted steering angle and confidence level.